### PR TITLE
chore: 📢 Bump version to 0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-svelte-state-snapshot-window",
-  "version": "1.0.0",
+  "version": "0.2.0-next",
   "description": "ESLint rules to enforce $state.snapshot usage when passing Svelte $state variables to window.* calls (Electron IPC).",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
📢 Bump version to 0.2.0

0.1.2 has been released.

 Time to switch to the new 0.2.0 version 🥳
